### PR TITLE
Bug 51 : Text Correction in CLI.md and docusaurus.config.ts Files

### DIFF
--- a/docs/CLI/CLI.md
+++ b/docs/CLI/CLI.md
@@ -236,7 +236,7 @@ A new login with an already active session overwrites the previous session.
 
 Shows your login information such as **email** .
 ```json
-raaghu login-info
+raaghu login --info
 ```
 
 ### logout

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -9,7 +9,7 @@ const config: Config = {
 
   staticDirectories: ['public', 'static'],
   // Set the production url of your site here
-  url: 'https://docs.raaghu.io',
+  url: 'https://docs.raaghu.ai',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl: '/',

--- a/i18n/en/docusaurus-plugin-content-docs/current/CLI/CLI.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/CLI/CLI.md
@@ -236,7 +236,7 @@ A new login with an already active session overwrites the previous session.
 
 Shows your login information such as **email** .
 ```json
-raaghu login-info
+raaghu login --info
 ```
 
 ### logout

--- a/versioned_docs/version-7.2/CLI/CLI.md
+++ b/versioned_docs/version-7.2/CLI/CLI.md
@@ -236,7 +236,7 @@ A new login with an already active session overwrites the previous session.
 
 Shows your login information such as **email** .
 ```json
-raaghu login-info
+raaghu login --info
 ```
 
 ### logout

--- a/versioned_docs/version-7.3/CLI/CLI.md
+++ b/versioned_docs/version-7.3/CLI/CLI.md
@@ -236,7 +236,7 @@ A new login with an already active session overwrites the previous session.
 
 Shows your login information such as **email** .
 ```json
-raaghu login-info
+raaghu login --info
 ```
 
 ### logout

--- a/versioned_docs/version-7.4/CLI/CLI.md
+++ b/versioned_docs/version-7.4/CLI/CLI.md
@@ -236,7 +236,7 @@ A new login with an already active session overwrites the previous session.
 
 Shows your login information such as **email** .
 ```json
-raaghu login-info
+raaghu login --info
 ```
 
 ### logout

--- a/versioned_docs/version-8.0/CLI/CLI.md
+++ b/versioned_docs/version-8.0/CLI/CLI.md
@@ -236,7 +236,7 @@ A new login with an already active session overwrites the previous session.
 
 Shows your login information such as **email** .
 ```json
-raaghu login-info
+raaghu login --info
 ```
 
 ### logout

--- a/versioned_docs/version-8.1/CLI/CLI.md
+++ b/versioned_docs/version-8.1/CLI/CLI.md
@@ -236,7 +236,7 @@ A new login with an already active session overwrites the previous session.
 
 Shows your login information such as **email** .
 ```json
-raaghu login-info
+raaghu login --info
 ```
 
 ### logout


### PR DESCRIPTION
## Description

1. There were spelling mistake in the above files and changes are done accordingly.

## Screenshots:
1. CLI.md Files Changes : 
![image](https://github.com/Wai-Technologies/raaghu-docs/assets/157368672/89bd644b-43f2-4a55-893e-c8bfcaa110b8)

2. docusaurus.config.ts file changes :
![image](https://github.com/Wai-Technologies/raaghu-docs/assets/157368672/5ba37246-760a-45a5-b2c0-cfecdc943d06)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
